### PR TITLE
Updates version number to 1.3

### DIFF
--- a/Switch_Client/Makefile
+++ b/Switch_Client/Makefile
@@ -32,7 +32,7 @@ include $(DEVKITPRO)/libnx/switch_rules
 #---------------------------------------------------------------------------------
 APP_TITLE := SwitchXBOXController
 APP_AUTHOR := WerWolv
-APP_VERSION := 1.0.0
+APP_VERSION := 1.3.0
 
 TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build


### PR DESCRIPTION
Just figured I'd do this while I was here. The current release is version 1.2, but the next release (where this PR's changes will take effect) will likely be .1 higher, hence 1.3.

Fixes https://github.com/WerWolv/SwitchXBOXController/issues/7